### PR TITLE
feat: add configurable account exclusion for auto code review

### DIFF
--- a/cmd/server/config.yaml
+++ b/cmd/server/config.yaml
@@ -5,13 +5,13 @@ server:
 github:
   #token: "1234567890"
   webhook_url: "http://localhost:8888/hook"
-  
+
   # GitHub App 配置
   # app:
   #   app_id: 1032243  # GitHub App ID
   #   private_key_path: "/Users/dir/xxxxx.private-key.pem"  # GitHub App Private Key 文件路径
-    # 或者通过环境变量指定: private_key_env: "GITHUB_APP_PRIVATE_KEY"
-    # 或者直接配置: private_key: "-----BEGIN RSA PRIVATE KEY-----..."
+  # 或者通过环境变量指定: private_key_env: "GITHUB_APP_PRIVATE_KEY"
+  # 或者直接配置: private_key: "-----BEGIN RSA PRIVATE KEY-----..."
 
 workspace:
   base_dir: "/Users/jicarl/codeagent"
@@ -26,3 +26,10 @@ claude:
 gemini:
   container_image: "goplusorg/codeagent:v0.5"
   timeout: "30m"
+
+review:
+  excluded_accounts:
+    - "dependabot"
+    - "renovate"
+    - "github-actions"
+    - "qiniu-ci"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,3 +44,13 @@ mention:
     - "@qiniu-ai" # another company AI assistant
   # Default trigger (used when no specific trigger list is provided)
   default_trigger: "@qiniu-ci"
+
+# Review configuration
+review:
+  # List of accounts to exclude from automatic code review
+  # Supports multiple accounts and patterns
+  excluded_accounts:
+    - "dependabot" # GitHub's dependency bot
+    - "renovate" # Renovate bot
+    - "github-actions" # GitHub Actions bot
+    - "*-bot" # Pattern to exclude all accounts ending with -bot (optional)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	yaml "gopkg.in/yaml.v3"
@@ -24,6 +25,8 @@ type Config struct {
 	Commands CommandsConfig `yaml:"commands"`
 	// AI Mention Configuration
 	Mention MentionConfig `yaml:"mention"`
+	// Review Configuration
+	Review ReviewConfig `yaml:"review"`
 }
 
 type GeminiConfig struct {
@@ -80,6 +83,11 @@ type MentionConfig struct {
 	Triggers []string `yaml:"triggers"`
 	// 默认的mention目标（向后兼容）
 	DefaultTrigger string `yaml:"default_trigger"`
+}
+
+type ReviewConfig struct {
+	// 自动审查的排除账号，支持多个
+	ExcludedAccounts []string `yaml:"excluded_accounts"`
 }
 
 func Load(configPath string) (*Config, error) {
@@ -181,6 +189,10 @@ func (c *Config) loadFromEnv() {
 	if mentionTrigger := os.Getenv("MENTION_TRIGGER"); mentionTrigger != "" {
 		c.Mention.DefaultTrigger = mentionTrigger
 	}
+	// Review configuration from environment
+	if excludedAccounts := os.Getenv("REVIEW_EXCLUDED_ACCOUNTS"); excludedAccounts != "" {
+		c.Review.ExcludedAccounts = strings.Split(excludedAccounts, ",")
+	}
 }
 
 func loadFromEnv() *Config {
@@ -229,6 +241,9 @@ func loadFromEnv() *Config {
 		Mention: MentionConfig{
 			Triggers:       []string{getEnvOrDefault("MENTION_TRIGGER", "@qiniu-ci")},
 			DefaultTrigger: getEnvOrDefault("MENTION_TRIGGER", "@qiniu-ci"),
+		},
+		Review: ReviewConfig{
+			ExcludedAccounts: []string{},
 		},
 		CodeProvider: getEnvOrDefault("CODE_PROVIDER", "claude"),
 		UseDocker:    getEnvBoolOrDefault("USE_DOCKER", true),

--- a/internal/modes/review_handler_test.go
+++ b/internal/modes/review_handler_test.go
@@ -1,0 +1,211 @@
+package modes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qiniu/codeagent/internal/config"
+)
+
+func TestReviewHandler_isAccountExcluded(t *testing.T) {
+	// 创建测试配置
+	config := &config.Config{
+		Review: config.ReviewConfig{
+			ExcludedAccounts: []string{
+				"dependabot",
+				"renovate",
+				"test-bot",
+			},
+		},
+	}
+
+	// 创建ReviewHandler实例
+	handler := &ReviewHandler{
+		config: config,
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{
+			name:     "[bot] suffix account should be excluded",
+			username: "someuser[bot]",
+			expected: true,
+		},
+		{
+			name:     "[BOT] suffix account should be excluded",
+			username: "someuser[BOT]",
+			expected: true,
+		},
+		{
+			name:     "exact match dependabot should be excluded",
+			username: "dependabot",
+			expected: true,
+		},
+		{
+			name:     "exact match renovate should be excluded",
+			username: "renovate",
+			expected: true,
+		},
+		{
+			name:     "exact match test-bot should be excluded",
+			username: "test-bot",
+			expected: true,
+		},
+		{
+			name:     "my-bot should not be excluded (not in config)",
+			username: "my-bot",
+			expected: false,
+		},
+		{
+			name:     "normal user should not be excluded",
+			username: "normaluser",
+			expected: false,
+		},
+		{
+			name:     "user with bot in middle should not be excluded",
+			username: "mybotuser",
+			expected: false,
+		},
+		{
+			name:     "case insensitive match should work",
+			username: "DEPENDABOT",
+			expected: true,
+		},
+		{
+			name:     "user with -bot suffix should not be excluded (not [bot])",
+			username: "someuser-bot",
+			expected: false,
+		},
+		{
+			name:     "user with -BOT suffix should not be excluded (not [BOT])",
+			username: "someuser-BOT",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := handler.isAccountExcluded(ctx, tt.username)
+			if result != tt.expected {
+				t.Errorf("isAccountExcluded(%s) = %v, want %v", tt.username, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReviewHandler_isAccountExcluded_EmptyConfig(t *testing.T) {
+	// 测试空配置的情况
+	config := &config.Config{
+		Review: config.ReviewConfig{
+			ExcludedAccounts: []string{},
+		},
+	}
+
+	handler := &ReviewHandler{
+		config: config,
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{
+			name:     "[bot] suffix should still be excluded even with empty config",
+			username: "someuser[bot]",
+			expected: true,
+		},
+		{
+			name:     "normal user should not be excluded with empty config",
+			username: "normaluser",
+			expected: false,
+		},
+		{
+			name:     "-bot suffix should not be excluded with empty config (not [bot])",
+			username: "someuser-bot",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := handler.isAccountExcluded(ctx, tt.username)
+			if result != tt.expected {
+				t.Errorf("isAccountExcluded(%s) = %v, want %v", tt.username, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReviewHandler_isAccountExcluded_WildcardPatterns(t *testing.T) {
+	// 测试通配符模式
+	config := &config.Config{
+		Review: config.ReviewConfig{
+			ExcludedAccounts: []string{
+				"*dependabot*",
+				"*test*",
+				"prefix-*",
+				"*-suffix",
+			},
+		},
+	}
+
+	handler := &ReviewHandler{
+		config: config,
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		username string
+		expected bool
+	}{
+		{
+			name:     "pattern *dependabot* should match dependabot",
+			username: "dependabot",
+			expected: true,
+		},
+		{
+			name:     "pattern *dependabot* should match my-dependabot-user",
+			username: "my-dependabot-user",
+			expected: true,
+		},
+		{
+			name:     "pattern *test* should match testuser",
+			username: "testuser",
+			expected: true,
+		},
+		{
+			name:     "pattern prefix-* should match prefix-anything",
+			username: "prefix-anything",
+			expected: true,
+		},
+		{
+			name:     "pattern *-suffix should match anything-suffix",
+			username: "anything-suffix",
+			expected: true,
+		},
+		{
+			name:     "pattern should not match unrelated user",
+			username: "unrelated",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := handler.isAccountExcluded(ctx, tt.username)
+			if result != tt.expected {
+				t.Errorf("isAccountExcluded(%s) = %v, want %v", tt.username, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add review.excluded_accounts configuration option
- Support wildcard patterns and exact matching for excluded accounts
- Automatically exclude accounts ending with [bot]
- Skip auto-review for PRs from excluded authors
- Update configuration files with example excluded accounts