### PR TITLE
fix(template): optimize comment instructions to prevent duplicate comments

### DIFF
--- a/internal/context/template_generator.go
+++ b/internal/context/template_generator.go
@@ -433,7 +433,8 @@ Follow these steps:
 1. Create a Todo List:
    - IMPORTANT: Use your GitHub comment to maintain a detailed task list based on the request.
    - Format todos as a checklist (- [ ] for incomplete, - [x] for complete).
-   - IMPORTANT: If the tag <claude_comment_id> above is not empty, update the comment using mcp__codeagent__github-comments__update_comment, and each task is completed on the comment $CLAUDE_COMMENT_ID
+   - IMPORTANT: Since you have been provided with comment ID $CLAUDE_COMMENT_ID, update this existing comment using mcp__codeagent__github-comments__update_comment
+   - DO NOT create a new comment - always update the existing comment with ID $CLAUDE_COMMENT_ID
    - IMPORTANT: If the tag <claude_comment_id> above is empty, a comment needs to be created immediately by using mcp__codeagent__github-comments__create_comment, after successful creation, extract the json "id" from the response body, and subsequent update operations will be carried out on this id
 
 


### PR DESCRIPTION
## Summary

This PR implements Solution 1 from issue #367 to fix the duplicate comment problem.

## Changes Made

- **Modified ** to optimize template instructions
- **Replaced ambiguous logic** with clear, explicit instructions about comment handling
- **Added explicit prohibition** against creating new comments when  exists

## Problem Fixed

Previously, the template contained confusing instructions that led Claude to:
1. See a  (should update existing comment)
2. Misinterpret template instructions about creating todo lists
3. Attempt to create a new comment, then realize it should update the existing one

## Solution

Changed from ambiguous instructions:
```
- IMPORTANT: If the tag <claude_comment_id> above is not empty, update the comment using mcp__codeagent__github-comments__update_comment, and each task is completed on the comment $CLAUDE_COMMENT_ID
```

To clear, explicit instructions:
```
- IMPORTANT: Since you have been provided with comment ID $CLAUDE_COMMENT_ID, update this existing comment using mcp__codeagent__github-comments__update_comment
- DO NOT create a new comment - always update the existing comment with ID $CLAUDE_COMMENT_ID
```

## Testing

- ✅ Build test successful
- ✅ Code compiles without errors

Fixes #367